### PR TITLE
build: drop unused .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,0 @@
-*.log
-.npmrc
-src
-tsconfig.json


### PR DESCRIPTION
This package already has a `"files"` field in `package.json` so it wasn't making use of `.npmignore` anyway.

https://github.com/electron/notarize/blob/d0eabf3345c82aa0f0d94e071734694fea101ed9/package.json#L23-L25