### PR TITLE
fix: skip codesign check on pkg and dmg files

### DIFF
--- a/src/check-signature.ts
+++ b/src/check-signature.ts
@@ -25,6 +25,11 @@ const codesign = async (opts: NotarizeStapleOptions) => {
   return result;
 };
 export async function checkSignatures(opts: NotarizeStapleOptions): Promise<void> {
+  const fileExt = path.extname(opts.appPath);
+  if (fileExt === '.dmg' || fileExt === '.pkg') {
+    d('skipping codesign check for dmg or pkg file');
+    return;
+  }
   const [codesignResult, codesignInfo] = await Promise.all([codesign(opts), codesignDisplay(opts)]);
   let error = '';
 


### PR DESCRIPTION
Skip the codesign verification on `pkg` files because it does not need to be signed to be notarized. Fixes the issue introdocued in https://github.com/electron/notarize/pull/152#issuecomment-1820925064