### PR TITLE
fix: check notarytool response status

### DIFF
--- a/src/notarytool.ts
+++ b/src/notarytool.ts
@@ -76,10 +76,11 @@ export async function notarizeAndWaitForNotaryTool(opts: NotaryToolStartOptions)
     ];
 
     const result = await spawn('xcrun', notarizeArgs);
+    const output = result.output.trim();
 
-    if (result.code !== 0) {
+    if (result.code !== 0 || output.includes('Invalid')) {
       try {
-        const parsed = JSON.parse(result.output.trim());
+        const parsed = JSON.parse(output);
         if (parsed && parsed.id) {
           const logResult = await spawn('xcrun', [
             'notarytool',

--- a/src/notarytool.ts
+++ b/src/notarytool.ts
@@ -76,11 +76,10 @@ export async function notarizeAndWaitForNotaryTool(opts: NotaryToolStartOptions)
     ];
 
     const result = await spawn('xcrun', notarizeArgs);
-    const output = result.output.trim();
+    const parsed = JSON.parse(result.output.trim());
 
-    if (result.code !== 0 || output.includes('Invalid')) {
+    if (result.code !== 0 || !parsed.status || parsed.status !== 'Accepted') {
       try {
-        const parsed = JSON.parse(output);
         if (parsed && parsed.id) {
           const logResult = await spawn('xcrun', [
             'notarytool',


### PR DESCRIPTION
I tried to sign and notarize my application, but kept getting error `The staple and validate action failed! Error 65.`. It is not obvious why this happens and what does it mean. After some digging I found that the problem is with my certificate. I understand that this is not directly related to this package, but this package could save some time by providing additional information.

Here is the output:
```
  ...
  electron-notarize:notarytool zip succeeded, attempting to upload to Apple +10s
  electron-notarize:spawn spawning cmd: xcrun args: [
  'notarytool',
  'submit',
  '/var/folders/jk/arst/T/electron-notarize-QH83Xm/my-app.zip',
  '--apple-id',
  '*********',
  '--password',
  '*********',
  '--team-id',
  '*********',
  '--wait',
  '--output-format',
  'json'
] opts: {} +0ms
  electron-notarize:spawn cmd xcrun terminated with code: 0 +1m
  electron-notarize:notarytool result code 0, output: {"id":"arst-astt-1234","status":"Invalid","message":"Processing complete"} +1m // this line temporarily added by me for debugging
  electron-notarize:notarytool notarization success +0ms
  electron-notarize:helpers work succeeded +1m
  electron-notarize:staple attempting to staple app: /var/folders/jk/arst/T/electron-packager/tmp-R6J7Wo/my-app.app +0ms
  electron-notarize:spawn spawning cmd: xcrun args: [ 'stapler', 'staple', '-v', 'my-app.app' ] opts: {
  cwd: '/var/folders/jk/arst/T/electron-packager/tmp-R6J7Wo'
} +6ms
  electron-notarize:spawn cmd xcrun terminated with code: 65 +291ms
```

As you can see on line `electron-notarize:notarytool result code 0, output`, notary tool exited with code `0` which is treated as success, but the output contains status `Invalid`. Currently code checks only exit code and discards output, so notarization process continues even though it will definitely fail. And we and up with final error message which does not tell whats wrong and let us think that problem is with `staple` step:
```
CloudKit query for my-app.app (2/123456789456123) failed due to "Record not found".
Could not find base64 encoded ticket in response for 2/123456789456123
The staple and validate action failed! Error 65.
```

With provided change we get this result:
```
An unhandled rejection has occurred inside Forge:
Error: Failed to notarize via notarytool

{"message":"Processing complete","status":"Invalid","id":"arst-arst-1234"}
```

It does not explicitly tell what's wrong, but using `DEBUG` we can get all the information from notarization log:
```
  ...
  electron-notarize:spawn spawning cmd: xcrun args: [
  'notarytool',
  'log',
  'arst-arst-1234',
  '--apple-id',
  '*********',
  '--password',
  '*********',
  '--team-id',
  '*********'
] opts: {} +0ms
  electron-notarize:spawn cmd xcrun terminated with code: 0 +2s
  electron-notarize:notarytool notarization log {
  "logFormatVersion": 1,
  "jobId": "arst-arst-1234",
  "status": "Invalid",
  "statusSummary": "Archive contains critical validation errors",
  "statusCode": 4000,
  ...
```

Thank you.