### PR TITLE
fix: Brittle response parsing from notarytool

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   cfa: continuousauth/npm@2.1.0
-  node: electronjs/node@2.2.1
+  node: electronjs/node@2.2.2
 
 workflows:
   test_and_release:

--- a/src/notarytool.ts
+++ b/src/notarytool.ts
@@ -83,19 +83,20 @@ export async function notarizeAndWaitForNotaryTool(opts: NotaryToolStartOptions)
     ];
 
     const result = await spawn('xcrun', notarizeArgs);
-
-    if (result.code === 0) {
-      d('notarization success');
-      return;
-    }
+    const rawOut = result.output.trim();
 
     let parsed: any;
     try {
-      parsed = JSON.parse(result.output.trim());
+      parsed = JSON.parse(rawOut);
     } catch (err) {
       throw new Error(
-        `Failed to notarize via notarytool.  Failed with unexpected result: \n\n${result.output.trim()}`,
+        `Failed to notarize via notarytool.  Failed with unexpected result: \n\n${rawOut}`,
       );
+    }
+
+    if (result.code === 0 && parsed.status === 'Accepted') {
+      d('notarization success');
+      return;
     }
 
     let logOutput: undefined | string;


### PR DESCRIPTION
## Description

Electron builder is not handling responses from notarytool on my device (MacOS Sonoma 14.4.1, XCode 15.2).  The issue is it's trying to JSON.parse a string with the value:
```
Error: HTTP status code: 401. Invalid credentials. Username or password is incorrect. Use the app-specific password generated at appleid.apple.com. Ensure that all authentication arguments are correct.
```

## Solution
- Fix the ordering of the status code check for the result of `spawn`
- For extra safety, catch errors when `JSON.parse` fails.

## Compared log when errors

### Previous logs

```
• electron-builder  version=24.13.3 os=23.4.0
  • loaded configuration  file=/Users/connormeehan/projects/eyejack/eyejack-creator/electron-builder.config.js
  • description is missed in the package.json  appPackageFile=/Users/connormeehan/projects/eyejack/eyejack-creator/dist_electron/bundled/package.json
  • author is missed in the package.json  appPackageFile=/Users/connormeehan/projects/eyejack/eyejack-creator/dist_electron/bundled/package.json
  • writing effective config  file=dist_electron/bundled/dist/builder-effective-config.yaml
  • rebuilding native dependencies  dependencies=sharp@0.32.6 platform=darwin arch=x64
  • install prebuilt binary  name=sharp version=0.32.6 platform=darwin arch=x64 napi=
                                                                                       • packaging       platform=darwin arch=x64 electron=14.2.9 appOutDir=dist_electron/bundled/dist/mac
  • signing         file=dist_electron/bundled/dist/mac/EyeJack Creator 2024.app platform=darwin type=distribution identity=34E41E43ADF5846B288472E3BA659E71DC2369DB provisioningProfile=none
  ⨯ Unexpected token 'E', "Error: HTT"... is not valid JSON  failedTask=build stackTrace=SyntaxError: Unexpected token 'E', "Error: HTT"... is not valid JSON
SyntaxError: Unexpected token 'E', "Error: HTT"... is not valid JSON
    at JSON.parse (<anonymous>)
    at /Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/node_modules/@electron/notarize/src/notarytool.ts:79:25
    at Generator.next (<anonymous>)
    at fulfilled (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/node_modules/@electron/notarize/lib/notarytool.js:28:58)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
From previous event:
    at processImmediate (node:internal/timers:478:21)
From previous event:
    at readDirectoryAndSign (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/src/macPackager.ts:478:29)
    at MacPackager.signApp (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/src/macPackager.ts:488:11)
    at MacPackager.doSignAfterPack (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/src/platformPackager.ts:336:21)
    at MacPackager.doPack (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/src/platformPackager.ts:321:7)
    at MacPackager.pack (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/src/macPackager.ts:198:9)
    at Packager.doBuild (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/src/packager.ts:445:9)
    at executeFinally (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/builder-util/src/promise.ts:12:14)
    at Packager._build (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/src/packager.ts:379:31)
    at Packager.build (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/app-builder-lib/src/packager.ts:340:12)
    at executeFinally (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/builder-util/src/promise.ts:12:14)
```

### New logs

```
• electron-builder  version=24.13.3 os=23.4.0
  • loaded configuration  file=/Users/connormeehan/projects/eyejack/eyejack-creator/electron-builder.config.js
  • description is missed in the package.json  appPackageFile=/Users/connormeehan/projects/eyejack/eyejack-creator/dist_electron/bundled/package.json
  • author is missed in the package.json  appPackageFile=/Users/connormeehan/projects/eyejack/eyejack-creator/dist_electron/bundled/package.json
  • writing effective config  file=dist_electron/bundled/dist/builder-effective-config.yaml
  • rebuilding native dependencies  dependencies=sharp@0.32.6 platform=darwin arch=x64
  • install prebuilt binary  name=sharp version=0.32.6 platform=darwin arch=x64 napi=
                                                                                       • packaging       platform=darwin arch=x64 electron=14.2.9 appOutDir=dist_electron/bundled/dist/mac
  • signing         file=dist_electron/bundled/dist/mac/EyeJack Creator 2024.app platform=darwin type=distribution identity=34E41E43ADF5846B288472E3BA659E71DC2369DB provisioningProfile=none
  • skipped macOS notarization  reason=`notarize` options were set explicitly `false`
  ⨯ Failed to notarize via notarytool

Error: HTTP status code: 401. Invalid credentials. Username or password is incorrect. Use the app-specific password generated at appleid.apple.com. Ensure that all authentication arguments are correct.
  failedTask=build stackTrace=Error: Failed to notarize via notarytool

                     Error: HTTP status code: 401. Invalid credentials. Username or password is incorrect. Use the app-specific password generated at appleid.apple.com. Ensure that all authentication arguments are correct.

                         at /Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/@electron/notarize/src/notarytool.ts:87:13
    at Generator.next (<anonymous>)
    at fulfilled (/Users/connormeehan/projects/eyejack/eyejack-creator/node_modules/@electron/notarize/lib/notarytool.js:28:58)
    at processTicksAndRejections (node:internal/process/task_queues:95:5)

```