### PR TITLE
docs: clean up types and add API docs site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 lib
 *.log
 src/example.ts
+docs
+.vscode

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -3,5 +3,13 @@
   "tabWidth": 2,
   "singleQuote": true,
   "printWidth": 100,
-  "parser": "typescript"
+  "parser": "typescript",
+  "overrides": [
+    {
+      "files": ["*.json", "*.jsonc", "*.json5"],
+      "options": {
+        "parser": "json"
+      }
+    }
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -9,102 +9,163 @@ Electron Notarize
 ## Installation
 
 ```bash
-# npm
 npm install @electron/notarize --save-dev
-
-# yarn
-yarn add @electron/notarize --dev
 ```
 
 ## What is app "notarization"?
 
 From Apple's docs in XCode:
 
-> A notarized app is a macOS app that was uploaded to Apple for processing before it was distributed. When you export a notarized app from Xcode, it code signs the app with a Developer ID certificate and staples a ticket from Apple to the app. The ticket confirms that you previously uploaded the app to Apple.
+> A notarized app is a macOS app that was uploaded to Apple for processing before it was distributed.
+> When you export a notarized app from Xcode, it code signs the app with a Developer ID certificate
+> and staples a ticket from Apple to the app. The ticket confirms that you previously uploaded the app to Apple.
 
-> On macOS 10.14 and later, the user can launch notarized apps when Gatekeeper is enabled. When the user first launches a notarized app, Gatekeeper looks for the app’s ticket online. If the user is offline, Gatekeeper looks for the ticket that was stapled to the app.
+> On macOS 10.14 and later, the user can launch notarized apps when Gatekeeper is enabled.
+> When the user first launches a notarized app, Gatekeeper looks for the app’s ticket online.
+> If the user is offline, Gatekeeper looks for the ticket that was stapled to the app.
 
-Apple has made this a hard requirement as of 10.15 (Catalina).
+As macOS 10.15 (Catalina), Apple has made notarization a hard requirement for all applications
+distributed outside of the Mac App Store. App Store applications do not need to be notarized.
 
 ## Prerequisites
 
 For notarization, you need the following things:
 
 1. Xcode 13 or later installed on your Mac.
-2. An [Apple Developer](https://developer.apple.com/) account.
-3. [An app-specific password for your ADC account’s Apple ID](https://support.apple.com/HT204397).
-4. Your app may need to be signed with `hardened-runtime`, including the following entitlement:
-    1. `com.apple.security.cs.allow-jit`
+1. An [Apple Developer](https://developer.apple.com/) account.
+1. [An app-specific password for your ADC account’s Apple ID](https://support.apple.com/HT204397).
+1. Your app may need to be signed with `hardenedRuntime: true` option, with the `com.apple.security.cs.allow-jit` entitlement.
 
-  If you are using Electron 11 or below, you must add the `com.apple.security.cs.allow-unsigned-executable-memory` entitlement too.
-  When using version 12+, this entitlement should not be applied as it increases your app's attack surface.
+> [!NOTE]
+> If you are using Electron 11 or below, you must add the `com.apple.security.cs.allow-unsigned-executable-memory` entitlement too.
+> When using version 12+, this entitlement should not be applied as it increases your app's attack surface.
 
 ## API
 
-### Method: `notarize(opts): Promise<void>`
+`@electron/notarize` exposes a single `notarize` function that accepts the following parameters:
+* `appPath` — the absolute path to your codesigned and packaged Electron application.
+* additional options required for authenticating your Apple ID (see below)
 
-* `options` Object
-  * `tool` String - The notarization tool to use, default is `notarytool`.  Previously, the value `legacy` used `altool`, which [**stopped working** on November 1st 2023](https://developer.apple.com/news/?id=y5mjxqmn).
-  * `appPath` String - The absolute path to your `.app` file
-  * There are three authentication methods available:
-    * user name with password:
-      * `appleId` String - The username of your Apple Developer account
-      * `appleIdPassword` String - The [app-specific password](https://support.apple.com/HT204397) (not your Apple ID password).
-      * `teamId` String - The [team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/) you want to notarize under.
-    * ... or apiKey with apiIssuer:
-      * `appleApiKey` String - Absolute path to the `.p8` file containing the key. Required for JWT authentication. See Note on JWT authentication below.
-      * `appleApiKeyId` String - App Store Connect API key ID, for example, `T9GPZ92M7K`. Required for JWT authentication. See Note on JWT authentication below.
-      * `appleApiIssuer` String - Your App Store Connect API key issuer, for example, `c055ca8c-e5a8-4836-b61d-aa5794eeb3f4`. Required if `appleApiKey` is specified.
-    * ... or keychain with keychainProfile:
-      * `keychain` String (optional) - The name of the keychain or path to the keychain you stored notarization credentials in. If omitted, iCloud keychain is used by default.
-      * `keychainProfile` String - The name of the profile you provided when storing notarization credentials.
+The method returns a void Promise once app notarization is complete. Please note that notarization may take
+many minutes.
 
-## Safety when using `appleIdPassword`
+If the notarization process is unusually log for your application, see Apple Developer's docs to
+[Avoid long notarization response times and size limits](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow#3561440).
 
-1. Never hard code your password into your packaging scripts, use an environment
-variable at a minimum.
-2. It is possible to provide a keychain reference instead of your actual password (assuming that you have already logged into
-the Application Loader from Xcode).  For example:
+### Usage with app-specific password
 
-```javascript
-const password = `@keychain:"Application Loader: ${appleId}"`;
-```
+You can generate an [app-specific password](https://support.apple.com/en-us/102654) for your Apple ID
+to notarize your Electron applications.
 
-Another option is that you can add a new keychain item using either the Keychain Access app or from the command line using the `security` utility:
-
-```bash
-security add-generic-password -a "AC_USERNAME" -w <app_specific_password> -s "AC_PASSWORD"
-```
-where `AC_USERNAME` should be replaced with your Apple ID, and then in your code you can use:
-
-```javascript
-const password = `@keychain:AC_PASSWORD`;
-```
-
-## Notes on JWT authentication
-
-You can obtain an API key from [App Store Connect](https://appstoreconnect.apple.com/access/api). Create a _Team Key_ (not an _Individual Key_) with _App Manager_ access. Note down the Issuer ID and download the `.p8` file. This file is your API key and comes with the name of `AuthKey_<appleApiKeyId>.p8`. Provide the path to this file as the `appleApiKey` argument.
-
-## Notes on your teamId
-
-To get your `teamId` value, go to your [Apple Developer Account](https://developer.apple.com/account), then click on "Membership details", and there you will find your Team ID.
-
-## Debug
-
-[`debug`](https://www.npmjs.com/package/debug) is used to display logs and messages. You can use `export DEBUG=electron-notarize*` to log additional debug information from this module.
-
-## Example Usage
+This method also requires you to specify the [Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/)
+of the Developer Team you want to notarize under. An Apple ID may be part of multiple Teams.
 
 ```javascript
 import { notarize } from '@electron/notarize';
 
-async function packageTask () {
-  // Package your app here, and code sign with hardened runtime
-  await notarize({
-    appPath,
-    appleId,
-    appleIdPassword,
-    teamId,
-  });
-}
+await notarize({
+  appPath,
+  appleId, // Login name of your Apple Developer account
+  appleIdPassword, // App-specific password
+  teamId, // Team ID for your developer team
+});
 ```
+
+> [!IMPORTANT]
+> **Never hard code your app-specific password into your packaging scripts.** Use an environment
+> variable at a minimum.
+
+### Usage with App Store Connect API key
+
+Alternatively, you can also authenticate via JSON Web Token (JWT) with App Store Connect.
+
+You can obtain an API key from [App Store Connect](https://appstoreconnect.apple.com/access/integrations/api).
+Create a **Team Key** (not an _Individual Key_) with **App Manager** access.
+
+Note down the Issuer ID (UUID format) and Key ID (10-character alphanumeric string),
+and download the `.p8` API key file (`AuthKey_<appleApiKeyId>.p8`).
+For security purposes, the private key can only be downloaded once.
+
+Provide the absolute path to your API key as the `appleApiKey` argument.
+
+```javascript
+import { notarize } from '@electron/notarize';
+
+await notarize({
+  appPath,
+  appleApiKey, // Absolute path to API key (e.g. `/path/to/AuthKey_X0X0X0X0X0.p8`)
+  appleApiIssuer, // Issuer ID (e.g. `d5631714-a680-4b4b-8156-b4ed624c0845`)
+});
+```
+
+### Usage with Keychain credentials
+
+As an alternative to passing authentication options, you can also store your authentication
+credentials (for both API key and app-specific password strategies) in the macOS Keychain
+via the `xcrun notarytool` command-line utility.
+
+This method has the advantage of validating your notarization credentials before submitting
+your application for notarization.
+
+For example:
+
+```sh
+# App-specific password strategy
+xcrun notarytool store-credentials "my-app-password-profile"
+  --apple-id "<AppleID>"
+  --team-id <DeveloperTeamID>
+  --password <app_specific_password>
+```
+
+```sh
+# App Store Connect API key strategy
+xcrun notarytool store-credentials "my-api-key-profile"
+  --key "<PathToAPIKey>"
+  --key-id <KeyID>
+  --issuer <IssuerID>
+```
+
+Successful storage of your credentials will look like this:
+
+```
+This process stores your credentials securely in the Keychain. You reference these credentials later using a profile name.
+
+Validating your credentials...
+Success. Credentials validated.
+Credentials saved to Keychain.
+To use them, specify `--keychain-profile "my-api-key-profile"`
+```
+
+After successfully storing your credentials, pass the keychain profile name into
+the `keychainProfile` parameter.
+
+```javascript
+import { notarize } from '@electron/notarize';
+
+await notarize({
+  appPath,
+  keychainProfile,
+});
+```
+
+## Validating credentials
+
+When notarizing your application
+
+```
+Error: HTTP status code: 401. Invalid credentials. Username or password is incorrect.
+Use the app-specific password generated at appleid.apple.com. Ensure that all authentication arguments are correct.
+```
+
+## Validating app notarization
+
+To validate that notarization worked, you can use the `stapler` command-line utility:
+
+```sh
+stapler validate path/to/notarized.app
+```
+## Debug
+
+[`debug`](https://www.npmjs.com/package/debug) is used to display logs and messages.
+Run your notarization scripts with the `DEBUG=electron-notarize*` environment variable to log additional
+debug information from this module.

--- a/README.md
+++ b/README.md
@@ -147,25 +147,36 @@ await notarize({
   keychainProfile,
 });
 ```
+## Troubleshooting
 
-## Validating credentials
+### Debug logging
 
-When notarizing your application
+[`debug`](https://www.npmjs.com/package/debug) is used to display logs and messages.
+Run your notarization scripts with the `DEBUG=electron-notarize*` environment variable to log additional
+debug information from this module.
+
+### Validating credentials
+
+When notarizing your application, you may run into issues with validating your notarization
+credentials.
 
 ```
 Error: HTTP status code: 401. Invalid credentials. Username or password is incorrect.
 Use the app-specific password generated at appleid.apple.com. Ensure that all authentication arguments are correct.
 ```
 
-## Validating app notarization
+[Storing your credentials in Keychain](#usage-with-keychain-credentials) will validate your credentials before
+even GitHub.
+
+### Validating app notarization
 
 To validate that notarization worked, you can use the `stapler` command-line utility:
 
 ```sh
 stapler validate path/to/notarized.app
 ```
-## Debug
 
-[`debug`](https://www.npmjs.com/package/debug) is used to display logs and messages.
-Run your notarization scripts with the `DEBUG=electron-notarize*` environment variable to log additional
-debug information from this module.
+### Apple documentation
+
+Apple also provides additional debugging documentation on
+[Resolving common notarization issues](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues).

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "jest": "^29.0.0",
     "prettier": "^1.18.2",
     "ts-jest": "^29.0.0",
-    "typescript": "^4.8.4"
+    "typedoc": "~0.25.13",
+    "typedoc-plugin-missing-exports": "^2.2.0",
+    "typescript": "4.9.3"
   },
   "dependencies": {
     "debug": "^4.1.1",

--- a/src/check-signature.ts
+++ b/src/check-signature.ts
@@ -1,18 +1,18 @@
 import * as path from 'path';
 
 import { spawn } from './spawn';
-import { NotarizeStapleOptions } from './types';
+import { NotaryToolNotarizeAppOptions } from './types';
 import debug from 'debug';
 const d = debug('electron-notarize');
 
-const codesignDisplay = async (opts: NotarizeStapleOptions) => {
+const codesignDisplay = async (opts: NotaryToolNotarizeAppOptions) => {
   const result = await spawn('codesign', ['-dv', '-vvvv', '--deep', path.basename(opts.appPath)], {
     cwd: path.dirname(opts.appPath),
   });
   return result;
 };
 
-const codesign = async (opts: NotarizeStapleOptions) => {
+const codesign = async (opts: NotaryToolNotarizeAppOptions) => {
   d('attempting to check codesign of app:', opts.appPath);
   const result = await spawn(
     'codesign',
@@ -24,7 +24,7 @@ const codesign = async (opts: NotarizeStapleOptions) => {
 
   return result;
 };
-export async function checkSignatures(opts: NotarizeStapleOptions): Promise<void> {
+export async function checkSignatures(opts: NotaryToolNotarizeAppOptions): Promise<void> {
   const fileExt = path.extname(opts.appPath);
   if (fileExt === '.dmg' || fileExt === '.pkg') {
     d('skipping codesign check for dmg or pkg file');

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,21 @@ export { NotarizeOptions };
 
 export { validateNotaryToolAuthorizationArgs as validateAuthorizationArgs } from './validate-args';
 
+/**
+ * Sends your app to Apple for notarization with `notarytool` and staples a successful
+ * notarization result to the app bundle. This includes your {@link NotaryToolNotarizeAppOptions.appPath | appPath}
+ * as well as one of three valid credential authentication strategies.
+ * 
+ * See {@link NotaryToolCredentials} for authentication options.
+ * 
+ * @category Core
+ * @param args Options for notarization
+ * @returns The Promise resolves once notarization is complete. Note that this may take a few minutes.
+ */
 async function notarize(args: NotarizeOptionsNotaryTool): Promise<void>;
-/** @deprecated */
+/**
+ * @deprecated
+ */
 async function notarize(args: NotarizeOptionsLegacy): Promise<void>;
 
 async function notarize({ appPath, ...otherOptions }: NotarizeOptions) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,9 +21,9 @@ export { validateNotaryToolAuthorizationArgs as validateAuthorizationArgs } from
  * Sends your app to Apple for notarization with `notarytool` and staples a successful
  * notarization result to the app bundle. This includes your {@link NotaryToolNotarizeAppOptions.appPath | appPath}
  * as well as one of three valid credential authentication strategies.
- * 
+ *
  * See {@link NotaryToolCredentials} for authentication options.
- * 
+ *
  * @category Core
  * @param args Options for notarization
  * @returns The Promise resolves once notarization is complete. Note that this may take a few minutes.

--- a/src/staple.ts
+++ b/src/staple.ts
@@ -2,11 +2,11 @@ import debug from 'debug';
 import * as path from 'path';
 
 import { spawn } from './spawn';
-import { NotarizeStapleOptions } from './types';
+import { NotaryToolNotarizeAppOptions } from './types';
 
 const d = debug('electron-notarize:staple');
 
-export async function stapleApp(opts: NotarizeStapleOptions): Promise<void> {
+export async function stapleApp(opts: NotaryToolNotarizeAppOptions): Promise<void> {
   d('attempting to staple app:', opts.appPath);
   const result = await spawn('xcrun', ['stapler', 'staple', '-v', path.basename(opts.appPath)], {
     cwd: path.dirname(opts.appPath),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,70 +1,186 @@
-/** @deprecated */
+/**
+ * @deprecated This interface was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
 export interface LegacyNotarizePasswordCredentials {
   appleId: string;
   appleIdPassword: string;
 }
 
+/**
+ * You can generate an [app-specific password](https://support.apple.com/en-us/102654) for your Apple ID
+ * to notarize your Electron applications.
+ *
+ * This method also requires you to specify the [Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/)
+ * of the Developer Team you want to notarize under. An Apple ID may be part of multiple Teams.
+ *
+ * @category Credential Strategies
+ */
 export interface NotaryToolPasswordCredentials {
+  /**
+   * The login username of your Apple Developer account.
+   */
   appleId: string;
+  /**
+   * An [app-specific password](https://support.apple.com/en-us/102654) for your
+   * Apple ID (**not** your Apple ID password).
+   *
+   * Do **not** hard code this password into your packaging scripts.
+   */
   appleIdPassword: string;
+  /**
+   * The [Team ID](https://developer.apple.com/help/account/manage-your-team/locate-your-team-id/)
+   * for the Developer Team you want to notarize under. Your Apple ID may be a member of multiple
+   * teams.
+   */
   teamId: string;
 }
 
-/** @deprecated */
+/**
+ * @deprecated This interface was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
 export interface LegacyNotarizeApiKeyCredentials {
   appleApiKey: string;
   appleApiIssuer: string;
 }
 
+/**
+ * Credentials required for JSON Web Token (JWT) notarization using App Store Connect API keys.
+ *
+ * @category Credential Strategies
+ */
 export interface NotaryToolApiKeyCredentials {
+  /**
+   * File system path to the `.p8` private key of your App Store Connect API key.
+   */
   appleApiKey: string;
+  /**
+   * App Store Connect API Key ID (e.g. `T9GPZ92M7K`).
+   *
+   */
   appleApiKeyId: string;
+  /**
+   * App Store Connect API Issuer ID. The issuer ID is a UUID format string
+   * (e.g. `c055ca8c-e5a8-4836-b61d-aa5794eeb3f4`).
+   */
   appleApiIssuer: string;
 }
 
+/**
+ * Options required for authenticating notarytool by storing
+ * credentials inside the system Keychain item.
+ *
+ * You can store {@link NotaryToolPasswordCredentials} or
+ * {@link NotaryToolApiKeyCredentials} into the Keychain
+ * using `xcrun notarytool store-credentials` and access the
+ * stored secrets when signing your code.
+ *
+ * @category Credential Strategies
+ */
 export interface NotaryToolKeychainCredentials {
+  /**
+   * The name of the profile you provided when storing notarization credentials.
+   */
   keychainProfile: string;
+  /**
+   * The name of the keychain or path to the keychain you stored notarization credentials in.
+   * @defaultValue If omitted, the system default `login` keychain will be used.
+   */
   keychain?: string;
 }
 
-/** @deprecated */
+/**
+ * @deprecated This interface was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
 export type LegacyNotarizeCredentials =
   | LegacyNotarizePasswordCredentials
   | LegacyNotarizeApiKeyCredentials;
+
+/**
+ * Credential options for authenticating `notarytool`. There are three valid stategies available:
+ * 
+ * - {@link NotaryToolPasswordCredentials} — Using an Apple ID and app-specific password
+ * - {@link NotaryToolApiKeyCredentials} — Using an App Store Connect API key
+ * - {@link NotaryToolKeychainCredentials} — Using one of the two above credential sets stored within the macOS Keychain
+ * @category Credential Strategies
+ */
 export type NotaryToolCredentials =
   | NotaryToolPasswordCredentials
   | NotaryToolApiKeyCredentials
   | NotaryToolKeychainCredentials;
-export type NotarizeCredentials = LegacyNotarizeCredentials | NotaryToolCredentials;
 
-/** @deprecated */
+/**
+ * @deprecated This interface was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
 export interface LegacyNotarizeAppOptions {
   appPath: string;
   appBundleId: string;
 }
 
+/**
+ * Non-credential options for notarizing your application with `notarytool`.
+ * @category Core
+ */
 export interface NotaryToolNotarizeAppOptions {
+  /**
+   * Absolute path to your packaged and codesigned Electron application.
+   */
   appPath: string;
 }
 
-export interface TransporterOptions {
+/**
+ * @deprecated This interface was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
+interface TransporterOptions {
   ascProvider?: string;
 }
 
-export interface NotarizeResult {
+/**
+ * @deprecated This interface was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
+interface NotarizeResult {
   uuid: string;
 }
 
-/** @deprecated */
+/**
+ * @deprecated This type was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
 export type LegacyNotarizeStartOptions = LegacyNotarizeAppOptions &
   LegacyNotarizeCredentials &
   TransporterOptions;
-export type NotaryToolStartOptions = NotaryToolNotarizeAppOptions & NotaryToolCredentials;
-/** @deprecated */
-export type LegacyNotarizeWaitOptions = NotarizeResult & LegacyNotarizeCredentials;
-export type NotarizeStapleOptions = Pick<LegacyNotarizeAppOptions, 'appPath'>;
 
-/** @deprecated */
+/**
+ * @deprecated This type was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
+export type LegacyNotarizeWaitOptions = NotarizeResult & LegacyNotarizeCredentials;
+
+/**
+ * @deprecated This type was used for Apple's `altool`, which was sunset in 2023 and no longer works.
+ * @category Legacy
+ */
 export type NotarizeOptionsLegacy = { tool: 'legacy' } & LegacyNotarizeStartOptions;
+
+/**
+ * Options for notarizing your Electron app with `notarytool`.
+ * @category Core
+ */
+export type NotaryToolStartOptions = NotaryToolNotarizeAppOptions & NotaryToolCredentials;
+
+/**
+ * Helper type that specifies that `@electron/notarize` is using the `notarytool` strategy.
+ * @category Utility Types
+ */
 export type NotarizeOptionsNotaryTool = { tool?: 'notarytool' } & NotaryToolStartOptions;
+
+/**
+ * Options accepted by the `notarize` method.
+ * @internal
+ */
 export type NotarizeOptions = NotarizeOptionsLegacy | NotarizeOptionsNotaryTool;

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,7 +100,7 @@ export type LegacyNotarizeCredentials =
 
 /**
  * Credential options for authenticating `notarytool`. There are three valid stategies available:
- * 
+ *
  * - {@link NotaryToolPasswordCredentials} — Using an Apple ID and app-specific password
  * - {@link NotaryToolApiKeyCredentials} — Using an App Store Connect API key
  * - {@link NotaryToolKeychainCredentials} — Using one of the two above credential sets stored within the macOS Keychain

--- a/src/validate-args.ts
+++ b/src/validate-args.ts
@@ -89,6 +89,9 @@ export function isNotaryToolKeychainCredentials(
   return creds.keychain !== undefined || creds.keychainProfile !== undefined;
 }
 
+/**
+ * @internal
+ */
 export function validateNotaryToolAuthorizationArgs(
   opts: NotaryToolCredentials,
 ): NotaryToolCredentials {

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["./src/index.ts"],
+  "plugin": ["typedoc-plugin-missing-exports"],
+  "placeInternalsInOwningModule": true,
+  "excludeInternal": true,
+  "navigation": {
+    "includeCategories": true
+  },
+  "defaultCategory": "Utility",
+  "categoryOrder": [
+    "Core",
+    "Credential Strategies",
+    "Utility Types",
+    "Legacy"
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -805,6 +805,11 @@ ansi-regex@^5.0.0, ansi-regex@^5.0.1:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.1.tgz#082cb2c89c9fe8659a311a53bd6a4dc5301db304"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -924,6 +929,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.2:
   version "3.0.2"
@@ -1817,6 +1829,11 @@ json5@^2.2.1:
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
 
+jsonc-parser@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz#031904571ccf929d7670ee8c547545081cb37f1a"
+  integrity sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==
+
 jsonfile@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.0.1.tgz#98966cba214378c8c84b82e085907b40bf614179"
@@ -1860,6 +1877,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
 make-dir@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-3.1.0.tgz#415e967046b3a7f1d185277d84aa58203726a13f"
@@ -1878,6 +1900,11 @@ makeerror@1.0.12:
   integrity sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==
   dependencies:
     tmpl "1.0.5"
+
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -1903,6 +1930,13 @@ minimatch@^3.0.4:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.3:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
+  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 ms@2.1.2:
   version "2.1.2"
@@ -2123,6 +2157,16 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shiki@^0.14.7:
+  version "0.14.7"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.7.tgz#c3c9e1853e9737845f1d2ef81b31bcfb07056d4e"
+  integrity sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==
+  dependencies:
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
+
 signal-exit@^3.0.3, signal-exit@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -2294,7 +2338,22 @@ type-fest@^0.21.3:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
   integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
-typescript@^4.8.4:
+typedoc-plugin-missing-exports@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/typedoc-plugin-missing-exports/-/typedoc-plugin-missing-exports-2.2.0.tgz#e39a04bab5b0d7f7b28507d64c07a4c40b788648"
+  integrity sha512-2+XR1IcyQ5UwXZVJe9NE6HrLmNufT9i5OwoIuuj79VxuA3eYq+Y6itS9rnNV1D7UeQnUSH8kISYD73gHE5zw+w==
+
+typedoc@~0.25.13:
+  version "0.25.13"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.13.tgz#9a98819e3b2d155a6d78589b46fa4c03768f0922"
+  integrity sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==
+  dependencies:
+    lunr "^2.3.9"
+    marked "^4.3.0"
+    minimatch "^9.0.3"
+    shiki "^0.14.7"
+
+typescript@4.9.3:
   version "4.9.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.3.tgz#3aea307c1746b8c384435d8ac36b8a2e580d85db"
   integrity sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==
@@ -2320,6 +2379,16 @@ v8-to-istanbul@^9.0.1:
     "@jridgewell/trace-mapping" "^0.3.12"
     "@types/istanbul-lib-coverage" "^2.0.1"
     convert-source-map "^1.6.0"
+
+vscode-oniguruma@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
+  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
+
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
 walker@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
Similar to electron/osx-sign#320 but for notarize.

Significant changes:
* Removal of `NotarizeStapleOptions` which is functionally identical to `NotaryToolNotarizeAppOptions`.
* Added details on keychain credential authentication and debugging notarization credentials
* Added more usage examples with each authentication strategy

See preview: https://erickzhao.github.io/notarize/