### PR TITLE
build: publish API documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,3 +21,9 @@ jobs:
           node-version: lts/*
       - run: yarn --frozen-lockfile
       - run: yarn build:docs
+      - name: Azure CLI script
+        uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd  # tag: v2.1.0
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az storage -h

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az storage blob upload-batch --account-name electronecosystemapidocs -d '$web/notarize/${{ github.ref_name }}' -s ./docs --overwrite --sas-token "$SAS_TOKEN"
+            az storage blob upload-batch --account-name $ACCOUNT_NAME -d '$web/notarize/${{ github.ref_name }}' -s ./docs --overwrite --sas-token "$SAS_TOKEN"
         env:
           SAS_TOKEN: ${{ secrets.SAS_TOKEN }}
+          ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,8 @@ name: Publish API documentation
 
 on:
   push:
+    branches:
+      - build/docs-website-action # TEST ACTION
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 
@@ -24,6 +26,6 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az storage blob upload-batch --account-name electronecosystemapidocs -d '$web' -s ./docs --overwrite --sas-token "$SAS_TOKEN"
+            az storage blob upload-batch --account-name electronecosystemapidocs -d '$web/notarize/${{ github.ref_name }}' -s ./docs --overwrite --sas-token "$SAS_TOKEN"
         env:
           SAS_TOKEN: ${{ secrets.SAS_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,6 @@
 name: Publish API documentation
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Publish API documentation
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az storage blob upload-batch --account-name electronecosystemapidocs -d '$web' -s ./docs --overwrite --sas-token "$SAS"
+            az storage blob upload-batch --account-name electronecosystemapidocs -d '$web' -s ./docs --overwrite --sas-token "$SAS_TOKEN"
         env:
-          SAS: ${{ secrets.SAS }}
+          SAS_TOKEN: ${{ secrets.SAS_TOKEN }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,7 @@
-name: Publish documentation
+name: Publish API documentation
 
 on:
   push:
-    branches:
-      - build/docs-website-action # TEST ACTION
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 
@@ -14,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # tag: v4.1.7
-      - name: Fetch all git branches
-        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b  # tag: v4.0.3
         with:
           node-version: lts/*
-      - run: yarn --frozen-lockfile
-      - run: yarn build:docs
-      - name: Azure CLI script
+      - name: Install dependencies
+        run: yarn --frozen-lockfile
+      - name: Build API documentation
+        run: yarn build:docs
+      - name: Upload to Azure Blob Storage
         uses: azure/cli@089eac9d8cc39f5d003e94f8b65efc51076c9cbd  # tag: v2.1.0
         with:
           azcliversion: latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,8 +2,6 @@ name: Publish API documentation
 
 on:
   push:
-    branches:
-      - build/docs-website-action # TEST ACTION
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   docs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # tag: v4.1.7
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b  # tag: v4.0.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,8 @@ permissions: {}
 jobs:
   docs:
     runs-on: ubuntu-24
+    environment: 
+      name: publish-docs
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # tag: v4.1.7
       - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b  # tag: v4.0.3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,4 +26,6 @@ jobs:
         with:
           azcliversion: latest
           inlineScript: |
-            az storage -h
+            az storage blob upload-batch --account-name electronecosystemapidocs -d '$web' -s ./docs --overwrite --sas-token "$SAS"
+        env:
+          SAS: ${{ secrets.SAS }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+name: Publish documentation
+
+on:
+  push:
+    branches:
+      - build/docs-website-action # TEST ACTION
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+*
+
+permissions: {}
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # tag: v4.1.7
+      - name: Fetch all git branches
+        run: git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
+      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b  # tag: v4.0.3
+        with:
+          node-version: lts/*
+      - run: yarn --frozen-lockfile
+      - run: yarn build:docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,8 +13,8 @@ jobs:
     environment: 
       name: publish-docs
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # tag: v4.1.7
-      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b  # tag: v4.0.3
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # tag: v4.2.2
+      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af  # tag: v4.1.0
         with:
           node-version: lts/*
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "build:docs": "npx typedoc",
     "lint": "prettier --check \"src/**/*.ts\"",
     "prepare": "yarn build",
     "test": "jest"


### PR DESCRIPTION
Adds a GitHub Action to generate TypeDoc API documentation and upload it to Azure Blob Storage with an SAS token.

See example run on my fork: https://github.com/erickzhao/notarize/actions/runs/11863393596/job/33064761419