### PR TITLE
fix: remove `graceful-fs` and use direct imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "devDependencies": {
     "@tsconfig/node22": "^22.0.0",
     "@types/debug": "^4.1.12",
-    "@types/graceful-fs": "^4.1.9",
     "@types/node": "~22.10.7",
     "@types/promise-retry": "^1.1.3",
     "prettier": "^3.4.2",
@@ -46,7 +45,6 @@
   },
   "dependencies": {
     "debug": "^4.4.0",
-    "graceful-fs": "^4.2.11",
     "promise-retry": "^2.0.1"
   }
 }

--- a/src/check-signature.ts
+++ b/src/check-signature.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import path from 'node:path';
 
 import { spawn } from './spawn.js';
 import { NotaryToolNotarizeAppOptions } from './types.js';

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,25 +1,24 @@
 import debug from 'debug';
-import * as fs from 'graceful-fs';
 
-import * as os from 'node:os';
-import * as path from 'node:path';
-import * as util from 'node:util';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 const d = debug('electron-notarize:helpers');
 
 export async function withTempDir<T>(fn: (dir: string) => Promise<T>) {
-  const dir = await util.promisify(fs.mkdtemp)(path.resolve(os.tmpdir(), 'electron-notarize-'));
+  const dir = await fs.promises.mkdtemp(path.resolve(os.tmpdir(), 'electron-notarize-'));
   d('doing work inside temp dir:', dir);
   let result: T;
   try {
     result = await fn(dir);
   } catch (err) {
     d('work failed');
-    await util.promisify(fs.rm)(dir, { recursive: true, force: true });
+    await fs.promises.rm(dir, { recursive: true, force: true });
     throw err;
   }
   d('work succeeded');
-  await util.promisify(fs.rm)(dir, { recursive: true, force: true });
+  await fs.promises.rm(dir, { recursive: true, force: true });
   return result;
 }
 

--- a/src/staple.ts
+++ b/src/staple.ts
@@ -1,5 +1,5 @@
 import debug from 'debug';
-import * as path from 'path';
+import path from 'node:path';
 
 import { spawn } from './spawn.js';
 import { NotaryToolNotarizeAppOptions } from './types.js';

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,9 +1,13 @@
-import { describe, expect, test } from 'vitest';
-import { parseNotarizationInfo } from '../src/helpers';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { parseNotarizationInfo, withTempDir } from '../src/helpers';
 
 describe('helpers', () => {
   describe('parseNotarizationInfo', () => {
-    test('build a NotarizationInfo object', () => {
+    it('build a NotarizationInfo object', () => {
       const output = `
 RequestUUID: 123
 Date: 2020-01-01
@@ -14,6 +18,18 @@ Status: unknown
         status: 'unknown',
         uuid: '123',
       });
+    });
+  });
+
+  describe('withTempDir', async () => {
+    it('creates a temporary directory and cleans it up afterwards', async () => {
+      let tmp: string | undefined;
+      await withTempDir(async (dir) => {
+        tmp = dir;
+      });
+      expect(tmp).toBeDefined();
+      expect(tmp).toContain(path.join(os.tmpdir(), 'electron-notarize-'));
+      expect(fs.existsSync(tmp!)).toBe(false);
     });
   });
 });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -7,7 +7,7 @@ import { parseNotarizationInfo, withTempDir } from '../src/helpers';
 
 describe('helpers', () => {
   describe('parseNotarizationInfo', () => {
-    it('build a NotarizationInfo object', () => {
+    it('builds a NotarizationInfo object', () => {
       const output = `
 RequestUUID: 123
 Date: 2020-01-01

--- a/yarn.lock
+++ b/yarn.lock
@@ -244,24 +244,10 @@
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.6.tgz#628effeeae2064a1b4e79f78e81d87b7e5fc7b50"
   integrity sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==
 
-"@types/graceful-fs@^4.1.9":
-  version "4.1.9"
-  resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.9.tgz#2a06bc0f68a20ab37b3e36aa238be6abdf49e8b4"
-  integrity sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==
-  dependencies:
-    "@types/node" "*"
-
 "@types/ms@*":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-2.1.0.tgz#052aa67a48eccc4309d7f0191b7e41434b90bb78"
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
-
-"@types/node@*":
-  version "22.13.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.10.tgz#df9ea358c5ed991266becc3109dc2dc9125d77e4"
-  integrity sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==
-  dependencies:
-    undici-types "~6.20.0"
 
 "@types/node@~22.10.7":
   version "22.10.7"
@@ -453,11 +439,6 @@ fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
-
-graceful-fs@^4.2.11:
-  version "4.2.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
-  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
 
 jsonc-parser@^3.2.0:
   version "3.2.1"


### PR DESCRIPTION
Closes #227

Uses `node:fs` directly instead of routing `graceful-fs` through `util.promisify`.

* Works around the issue where `import * as fs from 'graceful-fs'` would make the `fs` syntax look like `fs.default.fn()` instead of `fs.fn()`.
* `graceful-fs` doesn't patch `fs.rm` nor `fs.mkdtemp`, so it's safe to remove the package altogether and preserve previous behaviour.
* Adds a small unit test for the `withTempDir` helper, although I think `vitest` magic makes it so that the test passes even with the faulty runtime import.

cc @ckerr @erikian