### PR TITLE
chore: fix minor typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ For notarization, you need the following things:
 The method returns a void Promise once app notarization is complete. Please note that notarization may take
 many minutes.
 
-If the notarization process is unusually log for your application, see Apple Developer's docs to
+If the notarization process is unusually long for your application, see Apple Developer's docs to
 [Avoid long notarization response times and size limits](https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/customizing_the_notarization_workflow#3561440).
 
 ### Usage with app-specific password


### PR DESCRIPTION
- Minor typo `log -> long`