### PR TITLE
chore: remove unused delay helper

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -76,7 +76,3 @@ export function parseNotarizationInfo(info: string): NotarizationInfo {
 
   return out;
 }
-
-export function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
-}


### PR DESCRIPTION
This is unused and if we need it again there's the builtin `setTimeout` from `node:timers/promises` so no need for this helper.