### PR TITLE
Add support for individual API keys (Xcode 26 supported feature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ await notarize({
 Alternatively, you can also authenticate via JSON Web Token (JWT) with App Store Connect.
 
 You can obtain an API key from [App Store Connect](https://appstoreconnect.apple.com/access/integrations/api).
-Create a **Team Key** (not an _Individual Key_) with **App Manager** access.
+Create a **Team Key** with **App Manager** access.
 
 Note down the Issuer ID (UUID format) and Key ID (10-character alphanumeric string),
 and download the `.p8` API key file (`AuthKey_<appleApiKeyId>.p8`).
@@ -99,6 +99,8 @@ await notarize({
   appleApiIssuer, // Issuer ID (e.g. `d5631714-a680-4b4b-8156-b4ed624c0845`)
 });
 ```
+
+You can alternatively use an [individual API key](https://developer.apple.com/documentation/appstoreconnectapi/creating-api-keys-for-app-store-connect-api#Generate-an-Individual-Key) if (and only if) you are using Xcode 26+. When using an individual API key, it is imperative that you omit `appleApiIssuer` (issuer ID); otherwise you will receive a "401 Unauthorized" response from the server.
 
 ### Usage with Keychain credentials
 

--- a/src/notarytool.ts
+++ b/src/notarytool.ts
@@ -30,14 +30,18 @@ function authorizationArgs(rawOpts: NotaryToolCredentials): string[] {
       makeSecret(opts.teamId),
     ];
   } else if (isNotaryToolApiKeyCredentials(opts)) {
-    return [
-      '--key',
-      makeSecret(opts.appleApiKey),
-      '--key-id',
-      makeSecret(opts.appleApiKeyId),
-      '--issuer',
-      makeSecret(opts.appleApiIssuer),
-    ];
+    // --issuer is an optional argument as it must not be provided if using an Individual key; Individual keys can only be used with Xcode 26+
+    if (opts.appleApiIssuer) {
+      return [
+        '--key',
+        makeSecret(opts.appleApiKey),
+        '--key-id',
+        makeSecret(opts.appleApiKeyId),
+        '--issuer',
+        makeSecret(opts.appleApiIssuer),
+      ];
+    }
+    return ['--key', makeSecret(opts.appleApiKey), '--key-id', makeSecret(opts.appleApiKeyId)];
   } else {
     // --keychain is optional -- when not specified, the iCloud keychain is used by notarytool
     if (opts.keychain) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,9 +44,13 @@ export interface NotaryToolApiKeyCredentials {
   appleApiKeyId: string;
   /**
    * App Store Connect API Issuer ID. The issuer ID is a UUID format string
-   * (e.g. `c055ca8c-e5a8-4836-b61d-aa5794eeb3f4`).
+   * (e.g. `c055ca8c-e5a8-4836-b61d-aa5794eeb3f4`). Required for Team keys.
+   * Do not provide for Individual keys, this will result in a "401 Unauthorized"
+   * response from the server.
+   *
+   * Individual keys can only be used with Xcode 26+.
    */
-  appleApiIssuer: string;
+  appleApiIssuer?: string;
 }
 
 /**

--- a/src/validate-args.ts
+++ b/src/validate-args.ts
@@ -69,10 +69,6 @@ export function validateNotaryToolAuthorizationArgs(
       throw new Error(
         'The appleApiKey property is required when using notarization with ASC credentials',
       );
-    } else if (!apiKeyCreds.appleApiIssuer) {
-      throw new Error(
-        'The appleApiIssuer property is required when using notarization with ASC credentials',
-      );
     } else if (!apiKeyCreds.appleApiKeyId) {
       throw new Error(
         'The appleApiKeyId property is required when using notarization with ASC credentials',


### PR DESCRIPTION
Xcode 26 supports using an individual API key for notarization. The only difference is that when using an individual API key, you **mustn't** include the issuer ID, or else it will throw a 401 error. This library currently requires that `--issuer-id` be passed, so I've changed it so it's an optional parameter. I've also updated the README + JSDocs to document this.

Of course you're probably wanting an authoritative source for this, and that would be the man pages for notarytool.

Here is the man page when using Xcode 16:
![Screenshot 2025-06-21 at 01 48 52](https://github.com/user-attachments/assets/511a17cb-1e4c-4d54-8b8d-360a4ee44a64)

Here is the man page when using Xcode 26:
![Screenshot 2025-06-21 at 01 49 25](https://github.com/user-attachments/assets/7fb749cb-076f-4c60-a8db-edd4dbc8db8e)

For the sake of documenting explicitly: you can change what version of the Command Line Tools you're using (so you can see the different man pages) in the Xcode preferences:
![Screenshot 2025-06-21 at 01 51 18](https://github.com/user-attachments/assets/5251c097-92b0-443a-a6ef-d8d0c04be32d)

I've also attached a video where I attempt to sign an executable with an individual API key on both Xcode 16 and 26 (you'll see 16 fails but it works with 26):

https://github.com/user-attachments/assets/338726e7-0fa7-4e2a-a870-e1af8c0f49c1


