### PR TITLE
fix: export all relevant types from package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import { NotarizeOptions } from './types.js';
 
 const d = debug('electron-notarize');
 
-export { NotarizeOptions };
+export * from './types.js';
 
 export { validateNotaryToolAuthorizationArgs as validateAuthorizationArgs } from './validate-args.js';
 


### PR DESCRIPTION
Exports all types that are exported by `types.ts` so we can reference them in other packages (e.g. `@electron/packager`).